### PR TITLE
Fix breadcrumb link paths

### DIFF
--- a/bed-details.html
+++ b/bed-details.html
@@ -494,7 +494,7 @@
                 </li>
                 <li class="flex items-center gap-1.5">
                   <a
-                    href="/bed-details"
+                    href="bed-details.html"
                     class="hover:text-slate-900 transition-colors duration-150"
                   >
                     Bed Details

--- a/plant-details.html
+++ b/plant-details.html
@@ -490,7 +490,7 @@
               >
                 <li class="flex items-center gap-1.5">
                   <a
-                    href="/bed-details"
+                    href="bed-details.html"
                     class="hover:text-dashboard-text-primary transition-colors"
                   >
                     Bed Details
@@ -513,7 +513,7 @@
                 </li>
                 <li class="flex items-center gap-1.5">
                   <a
-                    href="/plant-details"
+                    href="plant-details.html"
                     class="hover:text-dashboard-text-primary transition-colors"
                   >
                     Plant


### PR DESCRIPTION
## Summary
- use `bed-details.html` and `plant-details.html` links in breadcrumbs

## Testing
- `npm run typecheck`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853787453f0832e97378d47cee6570b